### PR TITLE
Add an option to wait for client socket connections

### DIFF
--- a/src/rsb/transport/socket/BusServerImpl.h
+++ b/src/rsb/transport/socket/BusServerImpl.h
@@ -32,6 +32,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 #include <rsc/logging/Logger.h>
 
@@ -63,7 +64,8 @@ class RSB_EXPORT BusServerImpl : public virtual BusImpl,
 public:
     BusServerImpl(AsioServiceContextPtr    asioService,
                   boost::uint16_t          port,
-                  bool                     tcpnodelay);
+                  bool                     tcpnodelay,
+                  bool                     waitForClientDisconnects);
 
     virtual ~BusServerImpl();
 
@@ -76,6 +78,8 @@ public:
     void activate();
 
     void deactivate();
+
+    virtual void removeConnection(BusConnectionPtr connection);
 
     void handleIncoming(EventPtr         event,
                         BusConnectionPtr connection);
@@ -91,6 +95,10 @@ private:
 
     volatile bool                   active;
     volatile bool                   shutdown;
+
+    bool                            waitForClientDisconnects;
+
+    boost::condition_variable_any   shutdownCondition;
 
     // These two member functions have the additional ref parameter to
     // ensure that the BusServerImpl object cannot be destroyed while

--- a/src/rsb/transport/socket/ConnectorBase.cpp
+++ b/src/rsb/transport/socket/ConnectorBase.cpp
@@ -46,11 +46,12 @@ ConnectorBase::ConnectorBase(FactoryPtr                    factory,
                              const string&                 host,
                              unsigned int                  port,
                              Server                        server,
-                             bool                          tcpnodelay) :
+                             bool                          tcpnodelay,
+                             bool                          waitForClientDisconnects) :
     ConverterSelectingConnector<string>(converters),
     active(false), logger(Logger::getLogger("rsb.transport.socket.ConnectorBase")),
     factory(factory), host(host), port(port), server(server),
-    tcpnodelay(tcpnodelay) {
+    tcpnodelay(tcpnodelay), waitForClientDisconnects(waitForClientDisconnects) {
 }
 
 ConnectorBase::~ConnectorBase() {
@@ -83,7 +84,7 @@ void ConnectorBase::activate() {
     // getBus
     RSCINFO(logger, "Server mode: " << this->server);
     this->bus = this->factory->getBus(this->server, this->host, this->port,
-            this->tcpnodelay);
+            this->tcpnodelay, this->waitForClientDisconnects);
 
     this->active = true;
 

--- a/src/rsb/transport/socket/ConnectorBase.h
+++ b/src/rsb/transport/socket/ConnectorBase.h
@@ -80,13 +80,17 @@ public:
      *                   implementing the communication of the newly
      *                   created connector. Setting this option trades
      *                   decreased latency for decreased throughput.
+     * @param waitForClientDisconnects If true, delay shutdown of the server
+     *                                 socket until all clients have
+     *                                 disconnected.
      */
     ConnectorBase(FactoryPtr                    factory,
                   ConverterSelectionStrategyPtr converters,
                   const std::string&            host,
                   unsigned int                  port,
                   Server                        server,
-                  bool                          tcpnodelay);
+                  bool                          tcpnodelay,
+                  bool                          waitForClientDisconnects=true);
 
     virtual ~ConnectorBase();
 
@@ -122,6 +126,7 @@ private:
     unsigned int            port;
     Server                  server;
     bool                    tcpnodelay;
+    bool                    waitForClientDisconnects;
 };
 
 typedef boost::shared_ptr<ConnectorBase> ConnectorBasePtr;

--- a/src/rsb/transport/socket/Factory.h
+++ b/src/rsb/transport/socket/Factory.h
@@ -71,7 +71,8 @@ public:
     BusPtr getBus(const Server&          serverMode,
                   const std::string&     host,
                   const boost::uint16_t& port,
-                  bool                   tcpnodelay);
+                  bool                   tcpnodelay,
+                  bool                   waitForClientDisconnects);
 
 private:
     typedef std::pair<std::string, boost::uint16_t>	     Endpoint;
@@ -96,7 +97,8 @@ private:
 
     BusServerPtr getBusServerFor(const std::string& host,
                                  boost::uint16_t    port,
-                                 bool               tcpnodelay);
+                                 bool               tcpnodelay,
+                                 bool               waitForClientDisconnects);
 
     static void checkOptions(BusPtr bus, bool tcpnodelay);
 

--- a/src/rsb/transport/socket/InConnector.cpp
+++ b/src/rsb/transport/socket/InConnector.cpp
@@ -46,8 +46,10 @@ InConnector::InConnector(FactoryPtr                    factory,
                          const string&                 host,
                          unsigned int                  port,
                          Server                        server,
-                         bool                          tcpnodelay) :
-    ConnectorBase(factory, converters, host, port, server, tcpnodelay),
+                         bool                          tcpnodelay,
+                         bool                          waitForClientDisconnects) :
+    ConnectorBase(factory, converters, host, port, server, tcpnodelay,
+                  waitForClientDisconnects),
     logger(Logger::getLogger("rsb.transport.socket.InConnector")) {
 }
 

--- a/src/rsb/transport/socket/InConnector.h
+++ b/src/rsb/transport/socket/InConnector.h
@@ -70,7 +70,8 @@ public:
                 const std::string&            host,
                 unsigned int                  port,
                 Server                        server,
-                bool                          tcpnodelay);
+                bool                          tcpnodelay,
+                bool                          waitForClientDisconnects);
 
     virtual ~InConnector();
 

--- a/src/rsb/transport/socket/InPullConnector.cpp
+++ b/src/rsb/transport/socket/InPullConnector.cpp
@@ -51,7 +51,8 @@ transport::InPullConnector* InPullConnector::create(const Properties& args) {
                                args.get<string>                       ("host",       DEFAULT_HOST),
                                args.getAs<unsigned int>               ("port",       DEFAULT_PORT),
                                args.getAs<Server>                     ("server",     SERVER_AUTO),
-                               args.getAs<bool>                       ("tcpnodelay", true));
+                               args.getAs<bool>                       ("tcpnodelay", true),
+                               args.getAs<bool>                       ("wait", true));
 }
 
 InPullConnector::InPullConnector(FactoryPtr                    factory,
@@ -59,9 +60,12 @@ InPullConnector::InPullConnector(FactoryPtr                    factory,
                                  const string&                 host,
                                  unsigned int                  port,
                                  Server                        server,
-                                 bool                          tcpnodelay) :
-    ConnectorBase(factory, converters, host, port, server, tcpnodelay),
-    InConnector(factory, converters, host, port, server, tcpnodelay),
+                                 bool                          tcpnodelay,
+                                 bool                          waitForClientDisconnects) :
+    ConnectorBase(factory, converters, host, port, server, tcpnodelay,
+                  waitForClientDisconnects),
+    InConnector(factory, converters, host, port, server, tcpnodelay,
+                waitForClientDisconnects),
     logger(Logger::getLogger("rsb.transport.socket.InPullConnector")) {
 }
 

--- a/src/rsb/transport/socket/InPullConnector.h
+++ b/src/rsb/transport/socket/InPullConnector.h
@@ -75,7 +75,8 @@ public:
                     const std::string&            host,
                     unsigned int                  port,
                     Server                        server,
-                    bool                          tcpnodelay);
+                    bool                          tcpnodelay,
+                    bool                          waitForClientDisconnects=true);
 
     virtual ~InPullConnector();
 

--- a/src/rsb/transport/socket/InPushConnector.cpp
+++ b/src/rsb/transport/socket/InPushConnector.cpp
@@ -49,7 +49,8 @@ transport::InPushConnector* InPushConnector::create(const Properties& args) {
                                args.get<string>                       ("host",       DEFAULT_HOST),
                                args.getAs<unsigned int>               ("port",       DEFAULT_PORT),
                                args.getAs<Server>                     ("server",     SERVER_AUTO),
-                               args.getAs<bool>                       ("tcpnodelay", true));
+                               args.getAs<bool>                       ("tcpnodelay", true),
+                               args.getAs<bool>                       ("wait", true));
 }
 
 InPushConnector::InPushConnector(FactoryPtr                    factory,
@@ -57,9 +58,12 @@ InPushConnector::InPushConnector(FactoryPtr                    factory,
                                  const string&                 host,
                                  unsigned int                  port,
                                  Server                        server,
-                                 bool                          tcpnodelay) :
-    ConnectorBase(factory, converters, host, port, server, tcpnodelay),
-    InConnector(factory, converters, host, port, server, tcpnodelay),
+                                 bool                          tcpnodelay,
+                                 bool                          waitForClientDisconnects) :
+    ConnectorBase(factory, converters, host, port, server, tcpnodelay,
+                  waitForClientDisconnects),
+    InConnector(factory, converters, host, port, server, tcpnodelay,
+                waitForClientDisconnects),
     logger(Logger::getLogger("rsb.transport.socket.InPushConnector")) {
 }
 

--- a/src/rsb/transport/socket/InPushConnector.h
+++ b/src/rsb/transport/socket/InPushConnector.h
@@ -73,7 +73,8 @@ public:
                     const std::string&            host,
                     unsigned int                  port,
                     Server                        server,
-                    bool                          tcpnodelay);
+                    bool                          tcpnodelay,
+                    bool                          waitForClientDisconnects=true);
 
     virtual ~InPushConnector();
 

--- a/src/rsb/transport/socket/OutConnector.cpp
+++ b/src/rsb/transport/socket/OutConnector.cpp
@@ -50,7 +50,8 @@ transport::OutConnector* OutConnector::create(const Properties& args) {
                             args.get<string>                       ("host",       DEFAULT_HOST),
                             args.getAs<unsigned int>               ("port",       DEFAULT_PORT),
                             args.getAs<Server>                     ("server",     SERVER_AUTO),
-                            args.getAs<bool>                       ("tcpnodelay", true));
+                            args.getAs<bool>                       ("tcpnodelay", true),
+                            args.getAs<bool>                       ("wait", true));
 }
 
 OutConnector::OutConnector(FactoryPtr                    factory,
@@ -58,8 +59,10 @@ OutConnector::OutConnector(FactoryPtr                    factory,
                            const string&                  host,
                            unsigned int                   port,
                            Server                         server,
-                           bool                           tcpnodelay) :
-    ConnectorBase(factory, converters, host, port, server, tcpnodelay),
+                           bool                           tcpnodelay,
+                           bool                           waitForClientDisconnects) :
+    ConnectorBase(factory, converters, host, port, server, tcpnodelay,
+                  waitForClientDisconnects),
     logger(Logger::getLogger("rsb.transport.socket.OutConnector")){
 }
 

--- a/src/rsb/transport/socket/OutConnector.h
+++ b/src/rsb/transport/socket/OutConnector.h
@@ -57,7 +57,8 @@ public:
                  const std::string&            host,
                  unsigned int                  port,
                  Server                        server,
-                 bool                          tcpnodelay);
+                 bool                          tcpnodelay,
+                 bool                          waitForClientDisconnects=true);
 
     virtual ~OutConnector();
 

--- a/src/rsb/transport/transports.cpp
+++ b/src/rsb/transport/transports.cpp
@@ -73,6 +73,7 @@ void registerDefaultTransports() {
             options.insert("port");
             options.insert("server");
             options.insert("tcpnodelay");
+            options.insert("wait");
 
             factory.registerConnector("socket",
                                       &socket::InPushConnector::create,
@@ -100,6 +101,7 @@ void registerDefaultTransports() {
             options.insert("port");
             options.insert("server");
             options.insert("tcpnodelay");
+            options.insert("wait");
 
             factory.registerConnector("socket",
                                       &socket::InPullConnector::create,
@@ -126,6 +128,7 @@ void registerDefaultTransports() {
             options.insert("port");
             options.insert("server");
             options.insert("tcpnodelay");
+            options.insert("wait");
 
             factory.registerConnector("socket",
                                       &socket::OutConnector::create,


### PR DESCRIPTION
This commit adds an option for the socket transport to let the server
wait for all connected client connections to disconnect before
closing the listen socket. The default value for the new option is true.